### PR TITLE
when create a new HttpUrlSource object while response without cache, …

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -19,7 +19,7 @@ idea {
 }
 
 dependencies {
-    compile 'com.google.android:android:1.6_r2'
+    compile 'com.google.android:android:4.1.1.4'
 }
 
 publish {

--- a/library/src/main/java/com/danikula/videocache/HttpProxyCache.java
+++ b/library/src/main/java/com/danikula/videocache/HttpProxyCache.java
@@ -83,8 +83,9 @@ class HttpProxyCache extends ProxyCache {
     }
 
     private void responseWithoutCache(OutputStream out, long offset) throws ProxyCacheException, IOException {
+        HttpUrlSource source = null;
         try {
-            HttpUrlSource source = new HttpUrlSource(this.source);
+            source = new HttpUrlSource(this.source);
             source.open((int) offset);
             byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
             int readBytes;
@@ -94,7 +95,9 @@ class HttpProxyCache extends ProxyCache {
             }
             out.flush();
         } finally {
-            source.close();
+            if (source != null) {
+                source.close();
+            }
         }
     }
 

--- a/library/src/main/java/com/danikula/videocache/ProxyCache.java
+++ b/library/src/main/java/com/danikula/videocache/ProxyCache.java
@@ -18,7 +18,7 @@ import static com.danikula.videocache.ProxyCacheUtils.LOG_TAG;
  */
 class ProxyCache {
 
-    private static final int MAX_READ_SOURCE_ATTEMPTS = 1;
+    private static final int MAX_READ_SOURCE_ATTEMPTS = 6;
 
     private final Source source;
     private final Cache cache;

--- a/library/src/main/java/com/danikula/videocache/ProxyCacheUtils.java
+++ b/library/src/main/java/com/danikula/videocache/ProxyCacheUtils.java
@@ -92,4 +92,12 @@ public class ProxyCacheUtils {
         }
         return sb.toString();
     }
+
+    public static String intToIp(int i) {
+
+        return (i & 0xFF) + "." +
+                ((i >> 8) & 0xFF) + "." +
+                ((i >> 16) & 0xFF) + "." +
+                (i >> 24 & 0xFF);
+    }
 }


### PR DESCRIPTION
…can not close the exist old HttpUrlSource object.  this will cause data reading problem in SourceReaderRunnable thread.