### PR TITLE
#112: Cache trimmed only after cache hits

### DIFF
--- a/library/src/main/java/com/danikula/videocache/file/DiskUsage.java
+++ b/library/src/main/java/com/danikula/videocache/file/DiskUsage.java
@@ -12,4 +12,6 @@ public interface DiskUsage {
 
     void touch(File file) throws IOException;
 
+    void trim(File folder);
+
 }

--- a/library/src/main/java/com/danikula/videocache/file/FileCache.java
+++ b/library/src/main/java/com/danikula/videocache/file/FileCache.java
@@ -79,6 +79,7 @@ public class FileCache implements Cache {
         try {
             dataFile.close();
             diskUsage.touch(file);
+            diskUsage.trim(file.getParentFile());
         } catch (IOException e) {
             throw new ProxyCacheException("Error closing file " + file, e);
         }

--- a/library/src/main/java/com/danikula/videocache/file/LruDiskUsage.java
+++ b/library/src/main/java/com/danikula/videocache/file/LruDiskUsage.java
@@ -21,8 +21,19 @@ abstract class LruDiskUsage implements DiskUsage {
     private final ExecutorService workerThread = Executors.newSingleThreadExecutor();
 
     @Override
+    public void trim(File folder){
+        //folder passed in is the cache folder. Trim this if required
+        workerThread.submit(new TrimCallable(folder));
+    }
+
+    @Override
     public void touch(File file) throws IOException {
         workerThread.submit(new TouchCallable(file));
+    }
+
+    private void trimInBackground(File folder) throws IOException {
+        List<File> files = Files.getLruListFiles(folder);
+        trim(files);
     }
 
     private void touchInBackground(File file) throws IOException {
@@ -60,6 +71,7 @@ abstract class LruDiskUsage implements DiskUsage {
         return totalSize;
     }
 
+
     private class TouchCallable implements Callable<Void> {
 
         private final File file;
@@ -71,6 +83,21 @@ abstract class LruDiskUsage implements DiskUsage {
         @Override
         public Void call() throws Exception {
             touchInBackground(file);
+            return null;
+        }
+    }
+
+    private class TrimCallable implements Callable<Void> {
+
+        private final File folder;
+
+        public TrimCallable(File folder) {
+            this.folder = folder;
+        }
+
+        @Override
+        public Void call() throws Exception {
+            trimInBackground(folder);
             return null;
         }
     }

--- a/library/src/main/java/com/danikula/videocache/file/UnlimitedDiskUsage.java
+++ b/library/src/main/java/com/danikula/videocache/file/UnlimitedDiskUsage.java
@@ -14,4 +14,9 @@ public class UnlimitedDiskUsage implements DiskUsage {
     public void touch(File file) throws IOException {
         // do nothing
     }
+
+    @Override
+    public void trim(File folder){
+        // do nothing
+    }
 }


### PR DESCRIPTION
Added a new Callable - TrimCallable which only trims cache and not modify last accessed time of file since for cache misses last access time need not be modified manually but will be set automatically after file is fully cached. Used this callable to trim cache when a file is fully cached (100% content available)