### PR TITLE
Fixed a bug when handling non-cached range responses that aren't honored by the server.

### DIFF
--- a/library/src/main/java/com/danikula/videocache/HttpUrlSource.java
+++ b/library/src/main/java/com/danikula/videocache/HttpUrlSource.java
@@ -118,11 +118,15 @@ public class HttpUrlSource implements Source {
 
     @Override
     public int read(byte[] buffer) throws ProxyCacheException {
+        return read(buffer, buffer.length);
+    }
+
+    public int read(byte[] buffer, int length) throws ProxyCacheException {
         if (inputStream == null) {
             throw new ProxyCacheException("Error reading data from " + sourceInfo.url + ": connection is absent!");
         }
         try {
-            return inputStream.read(buffer, 0, buffer.length);
+            return inputStream.read(buffer, 0, length);
         } catch (InterruptedIOException e) {
             throw new InterruptedProxyCacheException("Reading source " + sourceInfo.url + " is interrupted", e);
         } catch (IOException e) {
@@ -198,6 +202,10 @@ public class HttpUrlSource implements Source {
 
     public String getUrl() {
         return sourceInfo.url;
+    }
+
+    public int getResponseCode() throws IOException {
+        return connection.getResponseCode();
     }
 
     @Override


### PR DESCRIPTION
Here's my use case: I'm playing music against a server that is unable to satisfy range requests. Instead, it returns an HTTP 200 and the full body. At this point, if the response is **not** in the cache, AndroidVideoCache ignores the offset and starts returning data from the beginning of the stream.

I realize this pull request may not be accepted because:
1. I'm not super familiar with the code base; the fix may be in the wrong spot.
2. I took a look at the test suite, but I'm not quite sure how to test this particular case. If you have an idea, let me know.

At any rate, I wanted you to be aware of the issue with a potential fix.