### PR TITLE
fix a bug : the redirect code in HttpUrlSource is not working, becaus…

### DIFF
--- a/library/src/main/java/com/danikula/videocache/HttpUrlSource.java
+++ b/library/src/main/java/com/danikula/videocache/HttpUrlSource.java
@@ -160,6 +160,7 @@ public class HttpUrlSource implements Source {
         do {
             LOG.debug("Open connection " + (offset > 0 ? " with offset " + offset : "") + " to " + url);
             connection = (HttpURLConnection) new URL(url).openConnection();
+            connection.setInstanceFollowRedirects(false);
             injectCustomHeaders(connection, url);
             if (offset > 0) {
                 connection.setRequestProperty("Range", "bytes=" + offset + "-");


### PR DESCRIPTION
English is poor, hope you understand.
HttpUrlConnection use a flag -- "instanceFollowRedirects", to define whether the protocol will automatically follow redirects or not. And the default value is true. So all redirects are handled by  httpUrlConnection automatically. The redirect logic in HttpUrlSource have no chance to be run. We need to invoke setInstanceFollowRedirects(false) to get that chance.